### PR TITLE
Rename exes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,11 +73,17 @@ jobs:
           path: |
             ponscr-question.zip
             ponscr-answer.zip
-      - name: Deploy
+      - name: Rename Files
         run: |
-          bash -c "([ "$TRAVIS_OS_NAME" != "linux" ] || sudo chown $USER key) && scp -o StrictHostKeyChecking=no -i key ponscr-question.zip ${UPLOAD_SERVER}/umineko_exe/umineko-$(cat buildinfo.txt)-question.zip 2> /dev/null"
-          bash -c "([ "$TRAVIS_OS_NAME" != "linux" ] || sudo chown $USER key) && scp -o StrictHostKeyChecking=no -i key ponscr-answer.zip ${UPLOAD_SERVER}/umineko_exe/umineko-$(cat buildinfo.txt)-answer.zip 2> /dev/null"
-        env:
-          UPLOAD_SERVER: ${{ secrets.UPLOAD_SERVER }}
-        if: github.ref == 'refs/heads/mod' && env.UPLOAD_SERVER != null
+          bash -c "mv ponscr-question.zip umineko-$(cat buildinfo.txt)-question.zip"
+          bash -c "mv ponscr-answer.zip umineko-$(cat buildinfo.txt)-answer.zip"
         shell: bash
+      # Publish a release, only on tagged commits
+      - name: Release (tag)
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') # only publish tagged commits
+        with:
+          files: umineko-*.zip
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.build.outputs.name }}
-          path: ponscr.zip
+          path: |
+            ponscr-question.zip
+            ponscr-answer.zip
       - name: Deploy
         run: |
           bash -c "([ "$TRAVIS_OS_NAME" != "linux" ] || sudo chown $USER key) && scp -o StrictHostKeyChecking=no -i key ponscr-question.zip ${UPLOAD_SERVER}/umineko_exe/umineko-$(cat buildinfo.txt)-question.zip 2> /dev/null"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,8 +72,9 @@ jobs:
           name: ${{ steps.build.outputs.name }}
           path: ponscr.zip
       - name: Deploy
-        run:
-          bash -c "([ "$TRAVIS_OS_NAME" != "linux" ] || sudo chown $USER key) && scp -o StrictHostKeyChecking=no -i key ponscr.zip ${UPLOAD_SERVER}/umineko-$(cat buildinfo.txt).zip 2> /dev/null"
+        run: |
+          bash -c "([ "$TRAVIS_OS_NAME" != "linux" ] || sudo chown $USER key) && scp -o StrictHostKeyChecking=no -i key ponscr-question.zip ${UPLOAD_SERVER}/umineko_exe/umineko-$(cat buildinfo.txt)-question.zip 2> /dev/null"
+          bash -c "([ "$TRAVIS_OS_NAME" != "linux" ] || sudo chown $USER key) && scp -o StrictHostKeyChecking=no -i key ponscr-answer.zip ${UPLOAD_SERVER}/umineko_exe/umineko-$(cat buildinfo.txt)-answer.zip 2> /dev/null"
         env:
           UPLOAD_SERVER: ${{ secrets.UPLOAD_SERVER }}
         if: github.ref == 'refs/heads/mod' && env.UPLOAD_SERVER != null

--- a/.travis_run.sh
+++ b/.travis_run.sh
@@ -49,9 +49,22 @@ fi
 
 cd src
 if [ "$TRAVIS_OS_NAME" == "windows" ]; then
-	zip -9 ../ponscr.zip ponscr.exe
+	cp ponscr.exe Umineko1to4.exe
+	cp ponscr.exe Umineko5to8.exe
+	zip -9 ../ponscr-question.zip Umineko1to4.exe
+	zip -9 ../ponscr-answer.zip Umineko5to8.exe
+elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
+	cp ponscr Umineko1to4
+	cp ponscr Umineko5to8
+	zip -9 ../ponscr-question.zip Umineko1to4
+	zip -9 ../ponscr-answer.zip Umineko5to8
 else
-	zip -9 ../ponscr.zip ponscr
+	mkdir -p Umineko1to4.app/Contents/MacOS
+	mkdir -p Umineko5to8.app/Contents/MacOS
+	cp ponscr Umineko1to4.app/Contents/MacOS/Umineko4
+	cp ponscr Umineko5to8.app/Contents/MacOS/Umineko8
+	zip -9 -r ../ponscr-question.zip Umineko1to4.app
+	zip -9 -r ../ponscr-answer.zip Umineko5to8.app
 fi
 cd ..
 

--- a/.travis_run.sh
+++ b/.travis_run.sh
@@ -59,8 +59,8 @@ elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
 	zip -9 ../ponscr-question.zip Umineko1to4
 	zip -9 ../ponscr-answer.zip Umineko5to8
 else
-	mkdir -p Umineko1to4.app/Contents/MacOS
-	mkdir -p Umineko5to8.app/Contents/MacOS
+	wget https://07th-mod.com/Beato/pre_2021_exe/umineko-mac-exe-base.zip
+	unzip umineko-mac-exe-base.zip
 	cp ponscr Umineko1to4.app/Contents/MacOS/Umineko4
 	cp ponscr Umineko5to8.app/Contents/MacOS/Umineko8
 	zip -9 -r ../ponscr-question.zip Umineko1to4.app


### PR DESCRIPTION
This PR creates copies of the executables as needed to match the Windows, Linux, and MacOS names, so they can be used as-is by the mod installer. It also creates a Github Release on tag instead of uploading to the server on each commit.