### PR TITLE
Unbreak on non-x86 archs after SSSE3 conditional

### DIFF
--- a/src/graphics_accelerated.cpp
+++ b/src/graphics_accelerated.cpp
@@ -104,6 +104,7 @@ void alphaMaskBlendConst_Basic(SDL_Surface* dst, SDL_Surface *s1, SDL_Surface *s
     }
 }
 
+#ifdef USE_X86_GFX
 enum Manufacturer {
     MF_UNKNOWN,
     MF_INTEL,
@@ -131,6 +132,7 @@ static bool hasFastPSHUFB(Manufacturer mf, int eax, int ecx) {
     }
     return true;
 }
+#endif
 
 AcceleratedGraphicsFunctions AcceleratedGraphicsFunctions::accelerated() {
     AcceleratedGraphicsFunctions out;


### PR DESCRIPTION
Regressed by 29c36286692a. From [aarch64 error log](https://github.com/07th-mod/ponscripter-fork/files/6982691/ponscripter-07th-mod-2.2.0.t.3.log):
```c
/usr/bin/c++ -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -c -MMD   -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -I/usr/local/include/gdk-pixbuf-2.0 -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.0/include -pthread  -I/usr/local/include/SDL2 -I/usr/local/include -D_REENTRANT -D_THREAD_SAFE -I/usr/local/include -I/usr/local/include/smpeg2 -I/usr/local/include/SDL2 -I/usr/local/include -D_REENTRANT -D_THREAD_SAFE -I/usr/local/include/freetype2 -I/usr/local/include/libpng16  -DLINUX -DUSE_OGG_VORBIS -DCONST_ICONV  -DLIBNOTIFY -DENABLE_JOYSTICK graphics_accelerated.cpp
graphics_accelerated.cpp:114:17: error: use of undeclared identifier 'bit_SSSE3'
    if (!(ecx & bit_SSSE3)) { return false; }
                ^
1 error generated.
```
