### PR TITLE
Add umineko spsize behavior and save/load fixes

### DIFF
--- a/src/PonscripterLabel.cpp
+++ b/src/PonscripterLabel.cpp
@@ -894,6 +894,13 @@ pstring Steam_GetSavePath(const pstring& local_savedir) {
     }
     savelocContent = pstring(pstr_split_first(savelocContent, '\n').first).trim();
     if (savelocContent) {
+        // Make sure there is some kind of slash at the end, otherwise the path will be interpreted as a file instead of a directory
+        // This only should happen if the saveloc file is edited manually, and the user does not add a slash.
+        if(!(savelocContent.ends_with("/") || savelocContent.ends_with("\\")))
+        {
+            savelocContent += "/";
+        }
+
         struct stat info;
         if (stat(path, &info) != 0 || !S_ISDIR(info.st_mode))
         {

--- a/src/PonscripterLabel.cpp
+++ b/src/PonscripterLabel.cpp
@@ -883,11 +883,10 @@ pstring Steam_GetSavePath(const pstring& local_savedir) {
     pstring saveloc = savedirdir + "saveloc.txt";
 
     FILE* savelocfile = fopen(saveloc, "r");
-    char path[512];
+    char path[512] = { 0 };
     pstring savelocContent;
-    path[0] = 0;
     if (savelocfile) {
-        while (fread(path, 1, sizeof(path), savelocfile)) {
+        while (fread(path, 1, sizeof(path)-1, savelocfile)) {
             savelocContent += path;
         }
         fclose(savelocfile);

--- a/src/PonscripterLabel.cpp
+++ b/src/PonscripterLabel.cpp
@@ -936,7 +936,8 @@ pstring Steam_GetSavePath(const pstring& local_savedir) {
     }
 
     if (savelocfile) {
-        PonscripterMessage(Error, "Steam Not Running", "Steam needs to be running to detect the appropriate save data location.  Please relaunch the game with Steam.  If this isn't actually a steam copy of the game, delete the file " + saveloc);
+        PonscripterMessage(Error, "Initial Save Location Setup - Steam Not Running", "Steam needs to be running to setup the save location.\n\nPlease relaunch the game with Steam running.\n\nIf this isn't actually a steam copy of the game, delete the file " + saveloc);
+        exit(-1);
     }
 
     fprintf(stderr, "Unable to get steam's save path; falling back to relative save path.\n");

--- a/src/PonscripterLabel.cpp
+++ b/src/PonscripterLabel.cpp
@@ -27,6 +27,7 @@
 #include "PonscripterMessage.h"
 #include "resources.h"
 #include <ctype.h>
+#include <sys/stat.h>
 
 #if defined(USE_PPC_GFX)
 # if defined(__linux__) || (defined(__FreeBSD__) && __FreeBSD__ >= 12)
@@ -893,6 +894,13 @@ pstring Steam_GetSavePath(const pstring& local_savedir) {
     }
     savelocContent = pstring(pstr_split_first(savelocContent, '\n').first).trim();
     if (savelocContent) {
+        struct stat info;
+        if (stat(path, &info) != 0 || !S_ISDIR(info.st_mode))
+        {
+            PonscripterMessage(Error, "Last Save Location Not Found", "The last used save location, '" + savelocContent + "', can't be opened.\n\nIf this is a Steam copy of the game, you should edit the contents of the " + saveloc + " file so that it is blank to use the default Steam location. You can also manually edit it to set the save folder.\n\nIf this isn't actually a Steam copy of the game, delete the file " + saveloc);
+            exit(-1);
+        }
+
         return savelocContent;
     }
     

--- a/src/PonscripterLabel_command.cpp
+++ b/src/PonscripterLabel_command.cpp
@@ -2286,14 +2286,15 @@ int PonscripterLabel::gettabCommand(const pstring& cmd)
 int PonscripterLabel::getspsizeCommand(const pstring& cmd)
 {
     int no = script_h.readIntValue();
+    int multiplier = multiplier_style <= ScriptHandler::UMINEKO ? 1 : res_multiplier;
 
     script_h.readIntExpr().mutate(
         (sprite_info[no].pos.w * screen_ratio2 / screen_ratio1) /
-        res_multiplier
+        multiplier
     );
     script_h.readIntExpr().mutate(
         (sprite_info[no].pos.h * screen_ratio2 / screen_ratio1) /
-        res_multiplier
+        multiplier
     );
     if (script_h.hasMoreArgs())
         script_h.readIntExpr().mutate(sprite_info[no].num_of_cells);


### PR DESCRIPTION
This PR fixes the following issues:

#### Graphics bugs with spsize command when using 2x mode 

 - https://github.com/07th-mod/ponscripter-fork/issues/6 fixed by 4a23c2a

#### Save/load related fixes

 - Fix the game launching even after error message is displayed telling you to restart the game. When this happened, it would use a save location you probably didn't intend. Now game will quit under this condition. c39f728 
- Fix unable to save/load in certain cases due to lack of null terminator  f31bff9 
- Add some niceties for save/load behavior 56e1f1e 92459a1
