### PR TITLE
Fix page breaks not working properly when any of the 'lang' series of commands are not used

### DIFF
--- a/src/PonscripterLabel_command.cpp
+++ b/src/PonscripterLabel_command.cpp
@@ -1739,6 +1739,7 @@ int PonscripterLabel::getreadlangCommand(const pstring& cmd)
 int PonscripterLabel::showlangenCommand(const pstring& cmd)
 {
     current_language = 0;
+    current_language_set = 1;
     //loadSaveFile(15);
     text_info.fill(0, 0, 0, 0);
     flush(refreshMode(), &sentence_font_info.pos);
@@ -1749,6 +1750,7 @@ int PonscripterLabel::showlangenCommand(const pstring& cmd)
 int PonscripterLabel::showlangjpCommand(const pstring& cmd)
 {
     current_language = 1;
+    current_language_set = 1;
     //loadSaveFile(15);
     text_info.fill(0, 0, 0, 0);
     flush(refreshMode(), &sentence_font_info.pos);
@@ -1759,6 +1761,7 @@ int PonscripterLabel::showlangjpCommand(const pstring& cmd)
 int PonscripterLabel::langenCommand(const pstring& cmd)
 {
     current_read_language = 0;
+    current_language_set = 1;
 
     return RET_CONTINUE;
 }
@@ -1769,6 +1772,7 @@ int PonscripterLabel::langjpCommand(const pstring& cmd)
     //    saveSaveFile(15);
     //}
     current_read_language = 1;
+    current_language_set = 1;
 
     return RET_CONTINUE;
 }
@@ -1776,6 +1780,7 @@ int PonscripterLabel::langjpCommand(const pstring& cmd)
 int PonscripterLabel::langallCommand(const pstring& cmd)
 {
     current_read_language = -1;
+    current_language_set = 1;
 
     return RET_CONTINUE;
 }

--- a/src/PonscripterLabel_text.cpp
+++ b/src/PonscripterLabel_text.cpp
@@ -432,7 +432,7 @@ int PonscripterLabel::clickNewPage(bool display_char)
 {
     const char* c = script_h.getStrBuf(string_buffer_offset);
 
-    if (current_read_language != -1 && current_read_language != current_language) {
+    if ((current_read_language != -1 && current_read_language != current_language) || (!current_language_set)) {
         clickstr_state = CLICK_NEWPAGE;
     }
 

--- a/src/ScriptParser.cpp
+++ b/src/ScriptParser.cpp
@@ -188,6 +188,7 @@ ScriptParser::ScriptParser()
 
     current_language = 0;
     current_read_language = -1;
+    current_language_set = 0;
     syscall_dict["skip"]        = SYSTEM_SKIP;
     syscall_dict["reset"]       = SYSTEM_RESET;
     syscall_dict["save"]        = SYSTEM_SAVE;
@@ -268,6 +269,7 @@ void ScriptParser::reset()
     max_text_buffer = MAX_TEXT_BUFFER;
     num_chars_in_sentence = 0;
     current_read_language = -1;
+    current_language_set = 0;
 
     // textbufferchange
     int i;

--- a/src/ScriptParser.h
+++ b/src/ScriptParser.h
@@ -379,6 +379,7 @@ protected:
     TextBuffer *start_text_buffer[2], *current_text_buffer[2];
     int current_language;
     int current_read_language;
+    int current_language_set;
 
     void TextBuffer_dumpstate(int = 0);
     int max_text_buffer;


### PR DESCRIPTION
Add a flag to be set when any of the 'lang' series of commands are used e.g. `langen`, `langjp`, `langall`.  
Only check `current_read_language` on page wait if `current_language_set` is set.  

Fixes page breaks not working properly when any of the 'lang' series of commands are not used.  
