### PR TITLE
Make '2x nscripter scaling' mode the default, and document it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         steam: ["-steam", ""]
-        os: [windows-2019, macos-10.15, ubuntu-20.04]
+        os: [windows-2019, macos-11, ubuntu-20.04]
         isinclude: [false] # Makes include add new jobs instead of editing existing ones
         include:
           - os: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -15,6 +15,35 @@ Other engines focussed on Western-language games include:
 * [Ponscripter](http://web.archive.org/web/20180812034417/http://unclemion.com/onscripter/) &mdash; The project this is based on
 * [Ren'Py](http://www.renpy.org/) &mdash; A modern visual novel engine with python scripting support.
 
+## Additional Features in this fork
+
+### Scaling Options
+
+#### Default Scaling
+
+> [!Warning]
+> On versions v3.0.2 and below, the "Umineko Steam release scaling mode" was the default, which could cause problems if you didn't specify a scaling mode (See [#17 where Umineko Saku 2019 had graphical issues on v3.0.2 and below](https://github.com/07th-mod/ponscripter-fork/issues/17)). This has been fixed on v4.0.0 and above.
+
+The default scaling option for our fork (as of v4.0.0) expects an input game resolution of 640x480 (eg. older nscripter games), and applies 2x mode (doubles everything). This is equivalent to explicitly setting the scaling mode with `;value2500,mode640@2x`.
+
+#### Normal Scaling Options
+
+This fork includes 2x mode, which can be used to support older Nscripter games at 2x resolution.
+
+This feature has been added as an extra argument to `;mode` (e.g. `;mode960@2x`).
+
+Widescreen support is also included, and can be enabled with `;modew720` or `;modew1080`.
+
+For example, our modded Umineko scripts have `;value2500,modew540@2x@umineko` as the first line of the script to give a 1920x1080 output resolution (as the input height of 540 is doubled). As for the `@umineko` option, see below.
+
+Please note that you MUST specify `mode` before specifying any other options like `@2x`, otherwise those commands will be ignored or cause problems.
+
+#### Umineko Steam Scaling Mode
+
+We've added an additional option for scaling to suit the Umineko Steam release. This changes the behavior of font scaling, and also the `getspsize` command - See d2b5d19 and e9c7e03.
+
+In most cases you will never need to use this scaling mode, but if you wish to enable it, add `@umineko` after the `mode` command, for example the very first commented line of your script could be something like `;value2500,modew540@2x@umineko`
+
 ### Documentation
 
 * [Ponscripter Tutorial](https://07th-mod.github.io/ponscripter-fork) - Most likely you should start here
@@ -70,9 +99,6 @@ record straight!
 ## 07th-Mod fork
 
 The 07th-Mod fork of this repo is brought to you with huge thanks to everyone mentioned above, but the latest changes are being maintained by the [07th-Mod](https://07th-mod.com) team. If you have any issues with this fork, please feel free to report them on the issues page or bother us on Discord about it.
-
-This includes 2x mode, which can be used to support older Nscripter games at 2x resolution. This feature has been added as an extra argument to `;mode` (e.g. `;mode960@2x`). Widescreen support is also included, and can be enabled with `;modew720` or `;modew1080`.
-
 
 ## License
 

--- a/src/ScriptHandler.cpp
+++ b/src/ScriptHandler.cpp
@@ -70,7 +70,7 @@ ScriptHandler::ScriptHandler()
     screen_width = 640;
     screen_height = 480;
     res_multiplier = 2; // Default to 2x mode for Umineko
-    multiplier_style = UMINEKO;
+    multiplier_style = FULL;
     global_variable_border = 200;
 
     // Prefer Ponscripter files over NScripter files, and prefer


### PR DESCRIPTION
- Make '2x nscripter scaling' mode the default by changing the default multiplier style from UMINEKO to FULL
- Roughly document how the scaling works, and what the default scaling is, on the Readme.md (hopefully I did this correctly...)
- See #17 for more details